### PR TITLE
Reactivity with decorators

### DIFF
--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -37,8 +37,8 @@ export default class PerspectiveCamera extends Node {
 
     three!: ThreePerspectiveCamera
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
 
         if (!this.isConnected) return
 

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -2,6 +2,7 @@ import {PerspectiveCamera as ThreePerspectiveCamera} from 'three'
 import {props} from './props'
 import Node from './Node'
 import {Scene} from './Scene'
+import {Props} from '../html/WithUpdate'
 type XYZValuesObject<T> = import('./XYZValues').XYZValuesObject<T>
 
 // TODO: update this to have a CSS3D-perspective-like API like with the Scene's
@@ -10,18 +11,18 @@ export default class PerspectiveCamera extends Node {
     static defaultElementName = 'i-perspective-camera'
 
     // TODO remove attributeChangedCallback, replace with updated based on these props
-    static props = {
-        ...(Node.props || {}),
+    static props: Props = {
         fov: {...props.number, default: 75},
         aspect: {
             ...props.number,
             default(): any {
                 return this._getDefaultAspect()
             },
-            deserialize(val: any) {
-                val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize(val)
+            deserialize(val: any, name: string) {
+                // TODO TS NormalizedPropDefinition, and remove the following non-null assertion
+                val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize!(val, name)
             },
-        },
+        } as ThisType<any>, // TODO TS `this` type for props
         near: {...props.number, default: 0.1},
         far: {...props.number, default: 1000},
         zoom: {...props.number, default: 1},

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -2,7 +2,7 @@ import {PerspectiveCamera as ThreePerspectiveCamera} from 'three'
 import {props} from './props'
 import Node from './Node'
 import {Scene} from './Scene'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 type XYZValuesObject<T> = import('./XYZValues').XYZValuesObject<T>
 
 // TODO: update this to have a CSS3D-perspective-like API like with the Scene's
@@ -11,29 +11,32 @@ export default class PerspectiveCamera extends Node {
     static defaultElementName = 'i-perspective-camera'
 
     // TODO remove attributeChangedCallback, replace with updated based on these props
-    static props: Props = {
-        fov: {...props.number, default: 75},
-        aspect: {
-            ...props.number,
-            default(): any {
-                return this._getDefaultAspect()
-            },
-            deserialize(val: any, name: string) {
-                // TODO TS NormalizedPropDefinition, and remove the following non-null assertion
-                val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize!(val, name)
-            },
-        } as ThisType<any>, // TODO TS `this` type for props
-        near: {...props.number, default: 0.1},
-        far: {...props.number, default: 1000},
-        zoom: {...props.number, default: 1},
-        active: {...props.boolean, default: false},
-    }
 
+    @prop({...props.number, default: 75})
     fov!: number
+
+    @prop({
+        ...props.number,
+        default(): any {
+            return this.__getDefaultAspect()
+        },
+        deserialize(val: any, _name: string) {
+            // TODO TS NormalizedPropDefinition, and remove the following non-null assertion
+            val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize(val)
+        },
+    } as ThisType<any>) // TODO TS `this` type for props
     aspect!: number
+
+    @prop({...props.number, default: 0.1})
     near!: number
+
+    @prop({...props.number, default: 1000})
     far!: number
+
+    @prop({...props.number, default: 1})
     zoom!: number
+
+    @prop({...props.boolean, default: false})
     active!: boolean
 
     three!: ThreePerspectiveCamera

--- a/src/core/LightBase.ts
+++ b/src/core/LightBase.ts
@@ -2,16 +2,14 @@ import {Color, Light} from 'three'
 import Node from './Node'
 import {props} from './props'
 import {mapPropTo} from './props'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 // base class for light elements.
 export default class LightBase extends Node {
-    static props: Props = {
-        color: mapPropTo({...props.THREE.Color, default: new Color('white')}, (self: any) => self.three),
-        intensity: mapPropTo({...props.number, default: 1}, (self: any) => self.three),
-    }
-
+    @prop(mapPropTo({...props.THREE.Color, default: new Color('white')}, (self: any) => self.three))
     color!: Color | string | number
+
+    @prop(mapPropTo({...props.number, default: 1}, (self: any) => self.three))
     intensity!: number
 
     three!: Light

--- a/src/core/LightBase.ts
+++ b/src/core/LightBase.ts
@@ -23,8 +23,8 @@ export default class LightBase extends Node {
         this.three.intensity = this.intensity
     }
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
 
         if (!this.isConnected) return
 

--- a/src/core/LightBase.ts
+++ b/src/core/LightBase.ts
@@ -2,11 +2,11 @@ import {Color, Light} from 'three'
 import Node from './Node'
 import {props} from './props'
 import {mapPropTo} from './props'
+import {Props} from '../html/WithUpdate'
 
 // base class for light elements.
 export default class LightBase extends Node {
-    static props = {
-        ...(Node.props || {}),
+    static props: Props = {
         color: mapPropTo({...props.THREE.Color, default: new Color('white')}, (self: any) => self.three),
         intensity: mapPropTo({...props.number, default: 1}, (self: any) => self.three),
     }

--- a/src/core/Mesh.ts
+++ b/src/core/Mesh.ts
@@ -53,8 +53,8 @@ export default class Mesh extends Node {
         this.three.receiveShadow = this.receiveShadow
     }
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
 
         if (!this.isConnected) return
 

--- a/src/core/Mesh.ts
+++ b/src/core/Mesh.ts
@@ -12,6 +12,7 @@ import '../html/behaviors/BoxGeometryBehavior'
 import '../html/behaviors/SphereGeometryBehavior'
 import '../html/behaviors/PlaneGeometryBehavior'
 import '../html/behaviors/DOMNodeGeometryBehavior'
+import {Props} from '../html/WithUpdate'
 
 // TODO:
 // - [ ] API for registering new behaviors as they pertain to our API, built on top
@@ -36,8 +37,7 @@ export default class Mesh extends Node {
         },
     }
 
-    static props = {
-        ...(Node.props || {}),
+    static props: Props = {
         castShadow: {...mapPropTo(props.boolean, (self: any) => self.three), default: true},
         receiveShadow: {...mapPropTo(props.boolean, (self: any) => self.three), default: true},
     }

--- a/src/core/Mesh.ts
+++ b/src/core/Mesh.ts
@@ -12,7 +12,7 @@ import '../html/behaviors/BoxGeometryBehavior'
 import '../html/behaviors/SphereGeometryBehavior'
 import '../html/behaviors/PlaneGeometryBehavior'
 import '../html/behaviors/DOMNodeGeometryBehavior'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 // TODO:
 // - [ ] API for registering new behaviors as they pertain to our API, built on top
@@ -37,12 +37,10 @@ export default class Mesh extends Node {
         },
     }
 
-    static props: Props = {
-        castShadow: {...mapPropTo(props.boolean, (self: any) => self.three), default: true},
-        receiveShadow: {...mapPropTo(props.boolean, (self: any) => self.three), default: true},
-    }
-
+    @prop({...mapPropTo(props.boolean, (self: any) => self.three), default: true})
     castShadow!: boolean
+
+    @prop({...mapPropTo(props.boolean, (self: any) => self.three), default: true})
     receiveShadow!: boolean
 
     three!: ThreeMesh

--- a/src/core/Motor.ts
+++ b/src/core/Motor.ts
@@ -91,7 +91,7 @@ class _Motor {
      * -- silence, crickets.
      */
     private async __startAnimationLoop() {
-        if (document.readyState === 'loading') await new Promise(resolve => setTimeout(resolve))
+        // if (document.readyState === 'loading') await new Promise(resolve => setTimeout(resolve))
 
         if (this.__loopStarted) return
 

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -59,8 +59,8 @@ function NodeMixin<T extends Constructor>(Base: T) {
             }
         }
 
-        updated(oldProps: any, modifiedProps: any) {
-            super.updated(oldProps, modifiedProps)
+        updated(modifiedProps: any) {
+            super.updated(modifiedProps)
 
             if (modifiedProps.visible) {
                 console.log(

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -6,7 +6,7 @@ import {props, mapPropTo} from './props'
 
 // register behaviors that can be used on this element
 import '../html/behaviors/ObjModelBehavior'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 initImperativeBase()
 
@@ -17,10 +17,7 @@ function NodeMixin<T extends Constructor>(Base: T) {
     class Node extends Parent {
         static defaultElementName = 'i-node'
 
-        static props: Props = {
-            visible: {...mapPropTo(props.boolean, (self: ImperativeBase) => self.three), default: true},
-        }
-
+        @prop({...mapPropTo(props.boolean, (self: ImperativeBase) => self.three), default: true})
         visible!: boolean
 
         isNode = true

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -6,6 +6,7 @@ import {props, mapPropTo} from './props'
 
 // register behaviors that can be used on this element
 import '../html/behaviors/ObjModelBehavior'
+import {Props} from '../html/WithUpdate'
 
 initImperativeBase()
 
@@ -16,8 +17,7 @@ function NodeMixin<T extends Constructor>(Base: T) {
     class Node extends Parent {
         static defaultElementName = 'i-node'
 
-        static props = {
-            ...(Parent.props || {}),
+        static props: Props = {
             visible: {...mapPropTo(props.boolean, (self: ImperativeBase) => self.three), default: true},
         }
 

--- a/src/core/PointLight.ts
+++ b/src/core/PointLight.ts
@@ -54,8 +54,8 @@ export default class PointLight extends LightBase {
         shadow.camera.far = this.shadowCameraFar
     }
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
 
         if (!this.isConnected) return
 

--- a/src/core/PointLight.ts
+++ b/src/core/PointLight.ts
@@ -2,12 +2,12 @@ import {PointLight as ThreePointLight} from 'three'
 import LightBase from './LightBase'
 import {props} from './props'
 import {mapPropTo} from './props'
+import {Props} from '../html/WithUpdate'
 
 export default class PointLight extends LightBase {
     static defaultElementName = 'i-point-light'
 
-    static props = {
-        ...LightBase.props,
+    static props: Props = {
         distance: mapPropTo({...props.number, default: 0}, (self: any) => self.three),
         decay: mapPropTo({...props.number, default: 1}, (self: any) => self.three),
         castShadow: mapPropTo({...props.boolean, default: true}, (self: any) => self.three),

--- a/src/core/PointLight.ts
+++ b/src/core/PointLight.ts
@@ -2,31 +2,36 @@ import {PointLight as ThreePointLight} from 'three'
 import LightBase from './LightBase'
 import {props} from './props'
 import {mapPropTo} from './props'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 export default class PointLight extends LightBase {
     static defaultElementName = 'i-point-light'
 
-    static props: Props = {
-        distance: mapPropTo({...props.number, default: 0}, (self: any) => self.three),
-        decay: mapPropTo({...props.number, default: 1}, (self: any) => self.three),
-        castShadow: mapPropTo({...props.boolean, default: true}, (self: any) => self.three),
-        shadowMapWidth: {...props.number, default: 512},
-        shadowMapHeight: {...props.number, default: 512},
-        shadowRadius: {...props.number, default: 3},
-        shadowBias: {...props.number, default: 0},
-        shadowCameraNear: {...props.number, default: 1},
-        shadowCameraFar: {...props.number, default: 2000},
-    }
-
+    @prop(mapPropTo({...props.number, default: 0}, (self: any) => self.three))
     distance!: number
+
+    @prop(mapPropTo({...props.number, default: 1}, (self: any) => self.three))
     decay!: number
+
+    @prop(mapPropTo({...props.boolean, default: true}, (self: any) => self.three))
     castShadow!: boolean
+
+    @prop({...props.number, default: 512})
     shadowMapWidth!: number
+
+    @prop({...props.number, default: 512})
     shadowMapHeight!: number
+
+    @prop({...props.number, default: 3})
     shadowRadius!: number
+
+    @prop({...props.number, default: 0})
     shadowBias!: number
+
+    @prop({...props.number, default: 1})
     shadowCameraNear!: number
+
+    @prop({...props.number, default: 2000})
     shadowCameraFar!: number
 
     three!: ThreePointLight

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -23,7 +23,7 @@ import {PerspectiveCamera} from './Camera'
 import {XYZValuesObject} from './XYZValues'
 import Sizeable from './Sizeable'
 import TreeNode from './TreeNode'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 initImperativeBase()
 
@@ -34,21 +34,22 @@ function SceneMixin<T extends Constructor>(Base: T) {
     class Scene extends Parent {
         static defaultElementName = 'i-scene'
 
-        static props: Props = {
-            backgroundColor: props.THREE.Color,
-            backgroundOpacity: props.number,
-            shadowmapType: props.string, //  TODO runtime check for ShadowMapTypeString
-            vr: props.boolean,
-            experimentalWebgl: props.boolean,
-            disableCss: props.boolean,
-        }
-
-        // TODO replace WithUpdate props with decorators
+        @prop(props.THREE.Color)
         backgroundColor!: Color | string | number
+
+        @prop(Number)
         backgroundOpacity!: number
+
+        @prop(String)
         shadowmapType!: ShadowMapTypeString
+
+        @prop(Boolean)
         vr!: boolean
+
+        @prop(Boolean)
         experimentalWebgl!: boolean
+
+        @prop(Boolean)
         disableCss!: boolean
 
         three!: ThreeScene

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -162,7 +162,7 @@ function SceneMixin<T extends Constructor>(Base: T) {
             this._mounted = false
         }
 
-        updated(oldProps: any, moddedProps: any) {
+        updated(moddedProps: any) {
             if (!this.isConnected) return
 
             if (moddedProps.experimentalWebgl) {
@@ -177,7 +177,7 @@ function SceneMixin<T extends Constructor>(Base: T) {
 
             // call super.updated() after the above _triggerLoadGL() so that WebGL
             // stuff will be ready in super.updated()
-            super.updated(oldProps, moddedProps)
+            super.updated(moddedProps)
 
             // if this.experimentalWebgl is true, then this.__glRenderer is defined in the following
             if (this.experimentalWebgl) {

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -23,6 +23,7 @@ import {PerspectiveCamera} from './Camera'
 import {XYZValuesObject} from './XYZValues'
 import Sizeable from './Sizeable'
 import TreeNode from './TreeNode'
+import {Props} from '../html/WithUpdate'
 
 initImperativeBase()
 
@@ -33,8 +34,7 @@ function SceneMixin<T extends Constructor>(Base: T) {
     class Scene extends Parent {
         static defaultElementName = 'i-scene'
 
-        static props = {
-            ...(Parent.props || {}),
+        static props: Props = {
             backgroundColor: props.THREE.Color,
             backgroundOpacity: props.number,
             shadowmapType: props.string, //  TODO runtime check for ShadowMapTypeString

--- a/src/core/Sizeable.ts
+++ b/src/core/Sizeable.ts
@@ -5,7 +5,7 @@ import XYZSizeModeValues from './XYZSizeModeValues'
 import XYZNonNegativeValues from './XYZNonNegativeValues'
 import Motor, {RenderTask} from './Motor'
 import {props} from './props'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 type XYZValuesObject<T> = import('./XYZValues').XYZValuesObject<T>
 type XYZValuesArray<T> = import('./XYZValues').XYZValuesArray<T>
 
@@ -33,11 +33,6 @@ function SizeableMixin<T extends Constructor>(Base: T) {
     // calculating proportional sizes. Also Transformable knows about it's parent
     // in order to calculate it's world matrix based on it's parent's.
     class Sizeable extends Parent {
-        static props: Props = {
-            size: props.XYZNonNegativeValues, // FIXME the whole app breaks on a negative value. Handle the error.
-            sizeMode: props.XYZSizeModeValues,
-        }
-
         // TODO remove any
         // protected _properties: (typeof Parent)['_props']
         protected _properties: any
@@ -76,6 +71,7 @@ function SizeableMixin<T extends Constructor>(Base: T) {
          * Set the size mode for each axis. Possible size modes are "literal"
          * and "proportional". The default values are "literal" for all axes.
          */
+        @prop(props.XYZSizeModeValues)
         set sizeMode(newValue) {
             if (typeof newValue === 'function') throw new TypeError('property functions are not allowed for sizeMode')
             this._setPropertyXYZ<Sizeable, SizeProp>('sizeMode', newValue)
@@ -112,6 +108,8 @@ function SizeableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis size to apply.
          * @param {number} [newValue.z] The z-axis size to apply.
          */
+        // TODO A scene breaks on a negative values. Should we clamp it to 0?
+        @prop(props.XYZNonNegativeValues)
         set size(newValue) {
             this._setPropertyXYZ<Sizeable, SizeProp>('size', newValue)
         }

--- a/src/core/Sizeable.ts
+++ b/src/core/Sizeable.ts
@@ -5,6 +5,7 @@ import XYZSizeModeValues from './XYZSizeModeValues'
 import XYZNonNegativeValues from './XYZNonNegativeValues'
 import Motor, {RenderTask} from './Motor'
 import {props} from './props'
+import {Props} from '../html/WithUpdate'
 type XYZValuesObject<T> = import('./XYZValues').XYZValuesObject<T>
 type XYZValuesArray<T> = import('./XYZValues').XYZValuesArray<T>
 
@@ -32,8 +33,7 @@ function SizeableMixin<T extends Constructor>(Base: T) {
     // calculating proportional sizes. Also Transformable knows about it's parent
     // in order to calculate it's world matrix based on it's parent's.
     class Sizeable extends Parent {
-        static props = {
-            ...(Parent.props || {}),
+        static props: Props = {
             size: props.XYZNonNegativeValues, // FIXME the whole app breaks on a negative value. Handle the error.
             sizeMode: props.XYZSizeModeValues,
         }

--- a/src/core/Sizeable.ts
+++ b/src/core/Sizeable.ts
@@ -50,11 +50,14 @@ function SizeableMixin<T extends Constructor>(Base: T) {
             this.__calculatedSize = {x: 0, y: 0, z: 0}
             this._properties = this._props // alias to WithUpdate._props
             this._setPropertyObservers()
-            this.properties = options
+
+            // is there a better way, without having to expose public "properties" or "props" properties like we did before?
+            // this.properties = options
+            Object.assign(this, options)
         }
 
         // TODO types for props
-        updated(_oldProps: any, modifiedProps: any) {
+        updated(modifiedProps: any) {
             if (!this.isConnected) return
 
             // this covers single-valued properties like opacity, but has the
@@ -131,24 +134,6 @@ function SizeableMixin<T extends Constructor>(Base: T) {
             // TODO
             // if (this.__sizeDirty) Protected(this._calcSize)
             return {...this.__calculatedSize}
-        }
-
-        /**
-         * Set all properties of a Sizeable in one method.
-         *
-         * @param {Object} properties Properties object - see example
-         *
-         * @example
-         * node.properties = {
-         *   sizeMode: {x:'literal', y:'proportional', z:'literal'},
-         *   size: {x:300, y:0.2, z:200},
-         * }
-         */
-        set properties(properties) {
-            this.props = properties
-        }
-        get properties() {
-            return this.props
         }
 
         makeDefaultProps() {

--- a/src/core/Transformable.ts
+++ b/src/core/Transformable.ts
@@ -5,6 +5,8 @@ import XYZNumberValues from './XYZNumberValues'
 import Sizeable, {SizeProp} from './Sizeable'
 import {props} from './props'
 import {toRadians} from './Utility'
+import {Props} from '../html/WithUpdate'
+// import {prop} from '../html/WithUpdate'
 
 // TODO, this module augmentation doesn't work as prescribed in
 // https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
@@ -54,8 +56,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
     // Transformable extends TreeNode (indirectly through Sizeable) because it
     // needs to be aware of its `parent` when calculating align adjustments.
     class Transformable extends Parent {
-        static props = {
-            ...(Parent.props || {}),
+        static props: Props = {
             position: props.XYZNumberValues,
             rotation: props.XYZNumberValues,
             scale: props.XYZNumberValues,
@@ -86,6 +87,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis rotation to apply.
          * @param {number} [newValue.z] The z-axis rotation to apply.
          */
+        // @prop(props.XYZNumberValues)
         set rotation(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('rotation', newValue)
         }

--- a/src/core/Transformable.ts
+++ b/src/core/Transformable.ts
@@ -5,8 +5,13 @@ import XYZNumberValues from './XYZNumberValues'
 import Sizeable, {SizeProp} from './Sizeable'
 import {props} from './props'
 import {toRadians} from './Utility'
-import {Props} from '../html/WithUpdate'
-// import {prop} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
+
+// TODO TS accessor typed also as Array, so that the accessors don't have to be
+// any, because accessor getters and setters currently have to have the same
+// type.
+//
+// type XYZAccessorType<T> = [T, T, T] & {x: T, y: T, z: T} & XYZValues<T>
 
 // TODO, this module augmentation doesn't work as prescribed in
 // https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
@@ -56,16 +61,6 @@ function TransformableMixin<T extends Constructor>(Base: T) {
     // Transformable extends TreeNode (indirectly through Sizeable) because it
     // needs to be aware of its `parent` when calculating align adjustments.
     class Transformable extends Parent {
-        static props: Props = {
-            position: props.XYZNumberValues,
-            rotation: props.XYZNumberValues,
-            scale: props.XYZNumberValues,
-            origin: props.XYZNumberValues,
-            align: props.XYZNumberValues,
-            mountPoint: props.XYZNumberValues,
-            opacity: props.number,
-        }
-
         /**
          * Set the position of the Transformable.
          *
@@ -74,6 +69,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis position to apply.
          * @param {number} [newValue.z] The z-axis position to apply.
          */
+        @prop(props.XYZNumberValues)
         set position(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('position', newValue)
         }
@@ -87,7 +83,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis rotation to apply.
          * @param {number} [newValue.z] The z-axis rotation to apply.
          */
-        // @prop(props.XYZNumberValues)
+        @prop(props.XYZNumberValues)
         set rotation(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('rotation', newValue)
         }
@@ -101,6 +97,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis scale to apply.
          * @param {number} [newValue.z] The z-axis scale to apply.
          */
+        @prop(props.XYZNumberValues)
         set scale(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('scale', newValue)
         }
@@ -114,6 +111,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis origin to apply.
          * @param {number} [newValue.z] The z-axis origin to apply.
          */
+        @prop(props.XYZNumberValues)
         set origin(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('origin', newValue)
         }
@@ -127,6 +125,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} opacity A floating point number clamped between 0 and
          * 1 (inclusive). 0 is fully transparent, 1 is fully opaque.
          */
+        @prop(props.number)
         set opacity(newValue: any) {
             this._setPropertySingle<Transformable, TransformProp>('opacity', newValue)
         }
@@ -143,6 +142,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis align to apply.
          * @param {number} [newValue.z] The z-axis align to apply.
          */
+        @prop(props.XYZNumberValues)
         set align(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('align', newValue)
         }
@@ -158,6 +158,7 @@ function TransformableMixin<T extends Constructor>(Base: T) {
          * @param {number} [newValue.y] The y-axis mountPoint to apply.
          * @param {number} [newValue.z] The z-axis mountPoint to apply.
          */
+        @prop(props.XYZNumberValues)
         set mountPoint(newValue: any) {
             this._setPropertyXYZ<Transformable, TransformProp>('mountPoint', newValue)
         }

--- a/src/core/props.ts
+++ b/src/core/props.ts
@@ -1,4 +1,4 @@
-import {props as basicProps} from '../html/WithUpdate'
+import {props as basicProps, PropDefinitionObject} from '../html/WithUpdate'
 import {Color} from 'three'
 import XYZValues from './XYZValues'
 import XYZNumberValues from './XYZNumberValues'
@@ -18,7 +18,7 @@ type XYZValuesConstructor = new (...args: any[]) => XYZValues
 // Behavior class hierarchies.
 function createXYZPropType<T extends XYZValuesConstructor, I extends InstanceType<T>>(_Type: T, override = {}) {
     return {
-        attribute: {source: true, target: false}, // get the value from an attribute (but don't mirror it back)
+        attribute: true, // get the value from an attribute (but don't reflect it back)
         coerce(this: any, val: any, propName: string): I {
             // if we have a property function, pass it along as is
             if (typeof val === 'function') return val
@@ -44,7 +44,7 @@ function createXYZPropType<T extends XYZValuesConstructor, I extends InstanceTyp
 
 function createGenericPropType<T extends Constructor<{}>>(Type: T, override = {}) {
     return {
-        attribute: {source: true, target: false}, // get the value from an attribute (but don't mirror it back)
+        attribute: true, // get the value from an attribute (but don't mirror it back)
         coerce: (val: any) => (val instanceof Type ? val : new Type(val)),
         default: new Type(),
         deserialize: (val: string) => new Type(val),
@@ -80,17 +80,9 @@ export const props = {
     XYZSizeModeValues: createXYZPropType(XYZSizeModeValues),
 }
 
-type PropDefinition<T = any> = {
-    // attribute?: {source?: boolean; target?: boolean}
-    coerce?<This>(this: This, val: any, propName: string): T
-    default?: T | (<This>(this: This, propName: string) => T)
-    deserialize?<This>(this: This, val: string, propName: string): T
-    serialize?<This>(this: This, val: any, propName: string): string
-}
-
 // map a SkateJS prop value to another target specified by getTarget
 // NOTE `this` refers to the instance on which the prop exists
-export const mapPropTo = (prop: PropDefinition, getTarget: (ctx: any) => object) => ({
+export const mapPropTo = (prop: PropDefinitionObject, getTarget: (ctx: any) => object) => ({
     ...prop,
     coerce: prop.coerce
         ? function coerce(this: any, val: any, key: string): any {
@@ -110,7 +102,7 @@ export const mapPropTo = (prop: PropDefinition, getTarget: (ctx: any) => object)
         : undefined,
 })
 
-export const changePropContext = (prop: PropDefinition, getContext: (ctx: any) => any) => ({
+export const changePropContext = (prop: PropDefinitionObject, getContext: (ctx: any) => any) => ({
     ...prop,
     coerce: prop.coerce
         ? function coerce(this: any, val: any, propName: string) {

--- a/src/html/behaviors/BaseGeometryBehavior.ts
+++ b/src/html/behaviors/BaseGeometryBehavior.ts
@@ -2,19 +2,16 @@ import BaseMeshBehavior, {MeshComponentType} from './BaseMeshBehavior'
 import {props, changePropContext} from '../../core/props'
 import XYZNonNegativeValues from '../../core/XYZNonNegativeValues'
 import {XYZSizeModeValues, SizeModeValue, XYZPartialValuesArray, XYZPartialValuesObject} from '../../core'
-import {Props} from '../WithUpdate'
+import {prop} from '../WithUpdate'
 
 // base class for geometry behaviors
 export default class BaseGeometryBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'geometry'
 
-    static props: Props = {
-        // if we have no props defined here, WithUpdate breaks
-        size: changePropContext(props.XYZNonNegativeValues, (self: BaseGeometryBehavior) => self.element),
-        sizeMode: changePropContext(props.XYZSizeModeValues, (self: BaseGeometryBehavior) => self.element),
-    }
-
+    @prop(changePropContext(props.XYZNonNegativeValues, (self: BaseGeometryBehavior) => self.element))
     size!: XYZNonNegativeValues | XYZPartialValuesArray<number> | XYZPartialValuesObject<number> | string
+
+    @prop(changePropContext(props.XYZSizeModeValues, (self: BaseGeometryBehavior) => self.element))
     sizeMode!: XYZSizeModeValues | XYZPartialValuesArray<SizeModeValue> | XYZPartialValuesObject<SizeModeValue> | string
 
     updated(modifiedProps: any) {

--- a/src/html/behaviors/BaseGeometryBehavior.ts
+++ b/src/html/behaviors/BaseGeometryBehavior.ts
@@ -16,7 +16,7 @@ export default class BaseGeometryBehavior extends BaseMeshBehavior {
     size!: XYZNonNegativeValues | XYZPartialValuesArray<number> | XYZPartialValuesObject<number> | string
     sizeMode!: XYZSizeModeValues | XYZPartialValuesArray<SizeModeValue> | XYZPartialValuesObject<SizeModeValue> | string
 
-    updated(_oldProps: any, modifiedProps: any) {
+    updated(modifiedProps: any) {
         const {size, sizeMode} = modifiedProps
 
         if (size || sizeMode) {

--- a/src/html/behaviors/BaseGeometryBehavior.ts
+++ b/src/html/behaviors/BaseGeometryBehavior.ts
@@ -2,12 +2,13 @@ import BaseMeshBehavior, {MeshComponentType} from './BaseMeshBehavior'
 import {props, changePropContext} from '../../core/props'
 import XYZNonNegativeValues from '../../core/XYZNonNegativeValues'
 import {XYZSizeModeValues, SizeModeValue, XYZPartialValuesArray, XYZPartialValuesObject} from '../../core'
+import {Props} from '../WithUpdate'
 
 // base class for geometry behaviors
 export default class BaseGeometryBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'geometry'
 
-    static props = {
+    static props: Props = {
         // if we have no props defined here, WithUpdate breaks
         size: changePropContext(props.XYZNonNegativeValues, (self: BaseGeometryBehavior) => self.element),
         sizeMode: changePropContext(props.XYZSizeModeValues, (self: BaseGeometryBehavior) => self.element),

--- a/src/html/behaviors/BaseMaterialBehavior.ts
+++ b/src/html/behaviors/BaseMaterialBehavior.ts
@@ -14,7 +14,7 @@ export default class BaseMaterialBehavior extends BaseMeshBehavior {
     color!: Color | string | number
     opacity!: number
 
-    updated(_oldProps: any, modifiedProps: any) {
+    updated(modifiedProps: any) {
         const {color, opacity} = modifiedProps
 
         if (color) this.updateMaterial('color')

--- a/src/html/behaviors/BaseMaterialBehavior.ts
+++ b/src/html/behaviors/BaseMaterialBehavior.ts
@@ -1,18 +1,16 @@
 import BaseMeshBehavior, {MeshComponentType} from './BaseMeshBehavior'
 import {props} from '../../core/props'
 import {Color, MeshPhongMaterial} from 'three'
-import {Props} from '../WithUpdate'
+import {prop} from '../WithUpdate'
 
 // base class for geometry behaviors
 export default class BaseMaterialBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'material'
 
-    static props: Props = {
-        color: props.THREE.Color,
-        opacity: {...props.number, default: 1},
-    }
-
+    @prop(props.THREE.Color)
     color!: Color | string | number
+
+    @prop({...props.number, default: 1})
     opacity!: number
 
     updated(modifiedProps: any) {

--- a/src/html/behaviors/BaseMaterialBehavior.ts
+++ b/src/html/behaviors/BaseMaterialBehavior.ts
@@ -1,12 +1,13 @@
 import BaseMeshBehavior, {MeshComponentType} from './BaseMeshBehavior'
 import {props} from '../../core/props'
 import {Color, MeshPhongMaterial} from 'three'
+import {Props} from '../WithUpdate'
 
 // base class for geometry behaviors
 export default class BaseMaterialBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'material'
 
-    static props = {
+    static props: Props = {
         color: props.THREE.Color,
         opacity: {...props.number, default: 1},
     }

--- a/src/html/behaviors/MaterialTexture.ts
+++ b/src/html/behaviors/MaterialTexture.ts
@@ -1,6 +1,6 @@
 import {Mixin, MixinResult, Constructor} from 'lowclass'
 import {TextureLoader, MeshPhongMaterial} from 'three'
-import WithUpdate, {Props} from '../WithUpdate'
+import WithUpdate, {prop} from '../WithUpdate'
 import Behavior from './Behavior'
 import {Mesh} from '../../core'
 
@@ -10,11 +10,9 @@ import {Mesh} from '../../core'
 function MaterialTextureMixin<T extends Constructor<Behavior>>(Base: T) {
     // TODO, use a Pick<> of HTMLElement instead, pick just parts WithUpdate needs.
     class MaterialTexture extends WithUpdate.mixin(Constructor<Behavior>(Base)) {
-        static props: Props = {
-            texture: String,
-        }
-
+        @prop(String)
         texture!: string
+
         element!: Mesh
 
         updated(modifiedProps: any) {

--- a/src/html/behaviors/MaterialTexture.ts
+++ b/src/html/behaviors/MaterialTexture.ts
@@ -1,6 +1,6 @@
 import {Mixin, MixinResult, Constructor} from 'lowclass'
 import {TextureLoader, MeshPhongMaterial} from 'three'
-import WithUpdate from '../WithUpdate'
+import WithUpdate, {Props} from '../WithUpdate'
 import Behavior from './Behavior'
 import {Mesh} from '../../core'
 
@@ -10,8 +10,7 @@ import {Mesh} from '../../core'
 function MaterialTextureMixin<T extends Constructor<Behavior>>(Base: T) {
     // TODO, use a Pick<> of HTMLElement instead, pick just parts WithUpdate needs.
     class MaterialTexture extends WithUpdate.mixin(Constructor<Behavior>(Base)) {
-        static props = {
-            ...((Base as any).props || {}),
+        static props: Props = {
             texture: String,
         }
 

--- a/src/html/behaviors/MaterialTexture.ts
+++ b/src/html/behaviors/MaterialTexture.ts
@@ -18,8 +18,8 @@ function MaterialTextureMixin<T extends Constructor<Behavior>>(Base: T) {
         texture!: string
         element!: Mesh
 
-        updated(oldProps: any, modifiedProps: any) {
-            super.updated && super.updated(oldProps, modifiedProps)
+        updated(modifiedProps: any) {
+            super.updated && super.updated(modifiedProps)
 
             const {texture} = modifiedProps
 

--- a/src/html/behaviors/ObjModelBehavior.ts
+++ b/src/html/behaviors/ObjModelBehavior.ts
@@ -28,7 +28,7 @@ export default class ObjModelBehavior extends Behavior {
     objLoader: any
     mtlLoader: any
 
-    updated(_oldProps: any, modifiedProps: any) {
+    updated(modifiedProps: any) {
         if (modifiedProps.obj || modifiedProps.mtl) {
             // TODO if only mtl changes, maybe we can update only the material
             // instead of reloading the whole object?

--- a/src/html/behaviors/ObjModelBehavior.ts
+++ b/src/html/behaviors/ObjModelBehavior.ts
@@ -7,7 +7,7 @@ import {disposeObjectTree, setRandomColorPhongMaterial, isRenderItem} from '../.
 import {Object3D} from 'three'
 // import * as THREE from 'three' // this import needed for OBJLoader and MTLLoader
 import BaseMaterialBehavior from './BaseMaterialBehavior'
-import {Props} from '../WithUpdate'
+import {prop} from '../WithUpdate'
 
 declare global {
     interface Element {
@@ -16,12 +16,16 @@ declare global {
 }
 
 export default class ObjModelBehavior extends Behavior {
-    static props: Props = {
-        obj: String, // path to obj file
-        mtl: String, // path to mtl file
-    }
-
+    /**
+     * path to a `.obj` file
+     */
+    @prop(String)
     obj!: string
+
+    /**
+     * path to a `.mtl` file
+     */
+    @prop(String)
     mtl!: string
 
     // TODO no any

--- a/src/html/behaviors/ObjModelBehavior.ts
+++ b/src/html/behaviors/ObjModelBehavior.ts
@@ -7,6 +7,7 @@ import {disposeObjectTree, setRandomColorPhongMaterial, isRenderItem} from '../.
 import {Object3D} from 'three'
 // import * as THREE from 'three' // this import needed for OBJLoader and MTLLoader
 import BaseMaterialBehavior from './BaseMaterialBehavior'
+import {Props} from '../WithUpdate'
 
 declare global {
     interface Element {
@@ -15,7 +16,7 @@ declare global {
 }
 
 export default class ObjModelBehavior extends Behavior {
-    static props = {
+    static props: Props = {
         obj: String, // path to obj file
         mtl: String, // path to mtl file
     }

--- a/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
+++ b/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
@@ -18,8 +18,8 @@ export class RoundedRectangleGeometryBehavior extends BaseGeometryBehavior {
 
     // element!: RoundedRectangle
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
 
         if (modifiedProps.cornerRadius) {
             // TODO this is extra work if super.updated already called this. See

--- a/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
+++ b/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
@@ -3,10 +3,10 @@ import {Shape /*, ShapeGeometry*/, ExtrudeGeometry} from 'three'
 // import {RoundedRectangle} from '../../components/RoundedRectangle'
 import BaseGeometryBehavior from './BaseGeometryBehavior'
 import {props, changePropContext} from '../../core/props'
+import {Props} from '../WithUpdate'
 
 export class RoundedRectangleGeometryBehavior extends BaseGeometryBehavior {
-    static props = {
-        ...BaseGeometryBehavior.props,
+    static props: Props = {
         cornerRadius: changePropContext(props.number, (self: any) => self.element),
     }
 

--- a/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
+++ b/src/html/behaviors/RoundedRectangleGeometryBehavior.ts
@@ -3,13 +3,10 @@ import {Shape /*, ShapeGeometry*/, ExtrudeGeometry} from 'three'
 // import {RoundedRectangle} from '../../components/RoundedRectangle'
 import BaseGeometryBehavior from './BaseGeometryBehavior'
 import {props, changePropContext} from '../../core/props'
-import {Props} from '../WithUpdate'
+import {prop} from '../WithUpdate'
 
 export class RoundedRectangleGeometryBehavior extends BaseGeometryBehavior {
-    static props: Props = {
-        cornerRadius: changePropContext(props.number, (self: any) => self.element),
-    }
-
+    @prop(changePropContext(props.number, (self: any) => self.element))
     cornerRadius!: number
 
     // static get requiredElementType() {

--- a/src/html/utils.ts
+++ b/src/html/utils.ts
@@ -14,22 +14,17 @@ export function empty(val: any): val is Nothing {
     return val == null
 }
 
-// return a new array with unique items (duplicates removed)
-export function unique<T>(array: T[]): T[] {
-    return Array.from(new Set(array))
-}
-
-// return a new object with `properties` picked from `source`
-export function pick<T extends object, K extends keyof T>(source: T, properties: K[]): Pick<T, K> {
-    let result: any = {}
-
-    properties.forEach(prop => {
-        result[prop] = source[prop]
-    })
-
-    return result
-}
-
 export function identity(v: any) {
     return v
+}
+
+export function delay(fn: any) {
+    Promise.resolve().then(fn)
+}
+
+export function singleLine(str: string): string {
+    return str
+        .split('\n')
+        .map(s => s.trim())
+        .join(' ')
 }

--- a/src/layout/AutoLayoutNode.ts
+++ b/src/layout/AutoLayoutNode.ts
@@ -85,8 +85,8 @@ export default class AutoLayoutNode extends Node {
         }
     }
 
-    updated(oldProps: any, modifiedProps: any) {
-        super.updated(oldProps, modifiedProps)
+    updated(modifiedProps: any) {
+        super.updated(modifiedProps)
         if (modifiedProps.visualFormat) {
             this.setVisualFormat(this.visualFormat)
         }

--- a/src/layout/AutoLayoutNode.ts
+++ b/src/layout/AutoLayoutNode.ts
@@ -23,7 +23,7 @@ import * as AutoLayout from 'autolayout'
 import Node from '../core/Node'
 import Motor from '../core/Motor'
 import {XYZPartialValuesArray} from '../core/XYZValues'
-import {Props} from '../html/WithUpdate'
+import {prop} from '../html/WithUpdate'
 
 export {AutoLayout}
 
@@ -49,10 +49,7 @@ export default class AutoLayoutNode extends Node {
         strict: false,
     }
 
-    static props: Props = {
-        visualFormat: String,
-    }
-
+    @prop(String)
     visualFormat!: string
 
     /**

--- a/src/layout/AutoLayoutNode.ts
+++ b/src/layout/AutoLayoutNode.ts
@@ -23,6 +23,7 @@ import * as AutoLayout from 'autolayout'
 import Node from '../core/Node'
 import Motor from '../core/Motor'
 import {XYZPartialValuesArray} from '../core/XYZValues'
+import {Props} from '../html/WithUpdate'
 
 export {AutoLayout}
 
@@ -48,8 +49,7 @@ export default class AutoLayoutNode extends Node {
         strict: false,
     }
 
-    static props = {
-        ...(Node.props || {}),
+    static props: Props = {
         visualFormat: String,
     }
 


### PR DESCRIPTION
Improve `WithUpdate.ts` so that it provides a `@prop()` decorator for specifying reactive properties. The old `static props` method still works too (but we won't feature `static props` in the upcoming documentation). There's an example in WithUpdate, in the jsdoc comment for `function reactive()`, plus all the custom element classes.