### PR TITLE
Make props cleaner

### DIFF
--- a/examples/autolayout-imperative.html
+++ b/examples/autolayout-imperative.html
@@ -52,6 +52,7 @@
                 castShadow: "true",
                 intensity: "0.5",
             })
+            debugger
 
             scene.add(pointLight)
 
@@ -81,12 +82,14 @@
             `
 
             const layout = new AutoLayoutNode({
-                size: [600, 400],
                 position: "0 0 0",
                 align: " 0.5 0.5 0",
                 mountPoint: " 0.5 0.5 0",
                 visualFormat: vfl2,
             })
+
+            debugger
+            layout.size = (x,y,z,t) => [ 600+200*Math.sin(t/1000), 400+200*Math.sin(t/1000), z ]
 
             layout.style = "background: rgba(0,0,0,0.3)"
 
@@ -132,8 +135,6 @@
             layout.add(child5, 'child5')
 
             scene.add(layout); // add layout to the scene
-
-            layout.size = (x,y,z,t) => [ 600+200*Math.sin(t/1000), 400+200*Math.sin(t/1000), z ]
 
             document.addEventListener('pointermove', e => {
                 e.preventDefault()

--- a/examples/buttons-with-shadow.html
+++ b/examples/buttons-with-shadow.html
@@ -94,7 +94,7 @@
                     <i-point-light
                         id="light"
                         color="white"
-                        position="300 300 300"
+                        position="300 300 360"
                         size="0 0 0"
                         cast-shadow="true"
                         intensity="0.8"
@@ -141,7 +141,17 @@
                         // exposed through the HTML API yet. work-in-progress...
                         // TODO this stuff should be doable via the HTML
                         Array.from( document.querySelectorAll('i-dom-plane') ).forEach(function(n) {
-                            n.three.material.opacity = 0.3
+                            // TODO Remove Promise.resolve: Promise.resolve
+                            // currently needed here because the opacity=1 prop
+                            // in BaseMaterialBehavior otherwise sets the value
+                            // after we set it here if we don't use a timeout.
+                            // We should make a separate material-opacity prop,
+                            // and opacity should be multiplicative relative to
+                            // the parent node.
+                            Promise.resolve().then(() => {
+                                n.three.material.opacity = 0.3
+                                n.needsUpdate()
+                            })
                         })
 
                         document.querySelector('#bg').three.material.opacity = 0.3

--- a/src/core/AmbientLight.ts
+++ b/src/core/AmbientLight.ts
@@ -6,7 +6,8 @@ export default class AmbientLight extends LightBase {
 
     protected _makeThreeObject3d() {
         const light = new ThreeAmbientLight()
-        light.intensity = 1 // default
+        // light.intensity = 1 // default
+        light.intensity = this.intensity
         return light
     }
 }

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -12,29 +12,21 @@ export default class PerspectiveCamera extends Node {
 
     // TODO remove attributeChangedCallback, replace with updated based on these props
 
-    @prop(Number)
-    fov = 75
+    @prop(Number) fov = 75
+    @prop(Number) near = 0.1
+    @prop(Number) far = 1000
+    @prop(Number) zoom = 1
+    @prop(Boolean) active = false
 
+    // TODO TS `this` type for props
     @prop({
         ...props.number,
         deserialize(val: any, _name: string) {
             // TODO TS NormalizedPropDefinition, and remove the following non-null assertion
             val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize(val)
         },
-    } as ThisType<any>) // TODO TS `this` type for props
+    } as ThisType<any>)
     aspect = this.__getDefaultAspect()
-
-    @prop(Number)
-    near = 0.1
-
-    @prop(Number)
-    far = 1000
-
-    @prop(Number)
-    zoom = 1
-
-    @prop(Boolean)
-    active = false
 
     three!: ThreePerspectiveCamera
 

--- a/src/core/Camera.ts
+++ b/src/core/Camera.ts
@@ -12,32 +12,29 @@ export default class PerspectiveCamera extends Node {
 
     // TODO remove attributeChangedCallback, replace with updated based on these props
 
-    @prop({...props.number, default: 75})
-    fov!: number
+    @prop(Number)
+    fov = 75
 
     @prop({
         ...props.number,
-        default(): any {
-            return this.__getDefaultAspect()
-        },
         deserialize(val: any, _name: string) {
             // TODO TS NormalizedPropDefinition, and remove the following non-null assertion
             val == null ? this.constructor.props.aspect.default.call(this) : props.number.deserialize(val)
         },
     } as ThisType<any>) // TODO TS `this` type for props
-    aspect!: number
+    aspect = this.__getDefaultAspect()
 
-    @prop({...props.number, default: 0.1})
-    near!: number
+    @prop(Number)
+    near = 0.1
 
-    @prop({...props.number, default: 1000})
-    far!: number
+    @prop(Number)
+    far = 1000
 
-    @prop({...props.number, default: 1})
-    zoom!: number
+    @prop(Number)
+    zoom = 1
 
-    @prop({...props.boolean, default: false})
-    active!: boolean
+    @prop(Boolean)
+    active = false
 
     three!: ThreePerspectiveCamera
 

--- a/src/core/LightBase.ts
+++ b/src/core/LightBase.ts
@@ -6,11 +6,11 @@ import {prop} from '../html/WithUpdate'
 
 // base class for light elements.
 export default class LightBase extends Node {
-    @prop(mapPropTo({...props.THREE.Color, default: new Color('white')}, (self: any) => self.three))
-    color!: Color | string | number
+    @prop(mapPropTo(props.THREE.Color, (self: any) => self.three))
+    color: Color | string | number = new Color('white')
 
-    @prop(mapPropTo({...props.number, default: 1}, (self: any) => self.three))
-    intensity!: number
+    @prop(mapPropTo(props.number, (self: any) => self.three))
+    intensity = 1
 
     three!: Light
 

--- a/src/core/LightBase.ts
+++ b/src/core/LightBase.ts
@@ -1,16 +1,12 @@
 import {Color, Light} from 'three'
 import Node from './Node'
 import {props} from './props'
-import {mapPropTo} from './props'
 import {prop} from '../html/WithUpdate'
 
 // base class for light elements.
 export default class LightBase extends Node {
-    @prop(mapPropTo(props.THREE.Color, (self: any) => self.three))
-    color: Color | string | number = new Color('white')
-
-    @prop(mapPropTo(props.number, (self: any) => self.three))
-    intensity = 1
+    @prop(props.THREE.Color) color: Color | string | number = new Color('white')
+    @prop(Number) intensity: number = 1
 
     three!: Light
 
@@ -25,6 +21,9 @@ export default class LightBase extends Node {
         super.updated(modifiedProps)
 
         if (!this.isConnected) return
+
+        if (modifiedProps.intensity) this._forwardProp('intensity', this.three)
+        if (modifiedProps.color) this._forwardProp('color', this.three)
 
         this.needsUpdate()
     }

--- a/src/core/Mesh.ts
+++ b/src/core/Mesh.ts
@@ -37,11 +37,11 @@ export default class Mesh extends Node {
         },
     }
 
-    @prop({...mapPropTo(props.boolean, (self: any) => self.three), default: true})
-    castShadow!: boolean
+    @prop(mapPropTo(props.boolean, (self: any) => self.three))
+    castShadow = true
 
-    @prop({...mapPropTo(props.boolean, (self: any) => self.three), default: true})
-    receiveShadow!: boolean
+    @prop(mapPropTo(props.boolean, (self: any) => self.three))
+    receiveShadow = true
 
     three!: ThreeMesh
 

--- a/src/core/Mesh.ts
+++ b/src/core/Mesh.ts
@@ -1,6 +1,6 @@
 import {Mesh as ThreeMesh, Material} from 'three'
 import Node from './Node'
-import {props, mapPropTo} from './props'
+import {props} from './props'
 
 // register behaviors that can be used on this element
 // TODO: maybe useDefaultNames() should register these, otherwise the user can
@@ -37,11 +37,8 @@ export default class Mesh extends Node {
         },
     }
 
-    @prop(mapPropTo(props.boolean, (self: any) => self.three))
-    castShadow = true
-
-    @prop(mapPropTo(props.boolean, (self: any) => self.three))
-    receiveShadow = true
+    @prop(props.boolean) castShadow = true
+    @prop(props.boolean) receiveShadow = true
 
     three!: ThreeMesh
 
@@ -57,14 +54,16 @@ export default class Mesh extends Node {
         if (!this.isConnected) return
 
         if (modifiedProps.castShadow) {
-            this.needsUpdate()
+            this._forwardProp('castShadow', this.three)
         }
 
         if (modifiedProps.receiveShadow) {
+            this._forwardProp('receiveShadow', this.three)
             // TODO handle material arrays
             ;(this.three.material as Material).needsUpdate = true
-            this.needsUpdate()
         }
+
+        this.needsUpdate()
     }
 
     protected _makeThreeObject3d() {

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -17,8 +17,8 @@ function NodeMixin<T extends Constructor>(Base: T) {
     class Node extends Parent {
         static defaultElementName = 'i-node'
 
-        @prop({...mapPropTo(props.boolean, (self: ImperativeBase) => self.three), default: true})
-        visible!: boolean
+        @prop(mapPropTo(props.boolean, (self: ImperativeBase) => self.three))
+        visible = true
 
         isNode = true
 

--- a/src/core/Node.ts
+++ b/src/core/Node.ts
@@ -2,7 +2,7 @@ import {Mixin, MixinResult, Constructor} from 'lowclass'
 import 'geometry-interfaces'
 import ImperativeBase, {initImperativeBase} from './ImperativeBase'
 import {default as HTMLInterface} from '../html/HTMLNode'
-import {props, mapPropTo} from './props'
+import {props} from './props'
 
 // register behaviors that can be used on this element
 import '../html/behaviors/ObjModelBehavior'
@@ -17,8 +17,7 @@ function NodeMixin<T extends Constructor>(Base: T) {
     class Node extends Parent {
         static defaultElementName = 'i-node'
 
-        @prop(mapPropTo(props.boolean, (self: ImperativeBase) => self.three))
-        visible = true
+        @prop(props.boolean) visible = true
 
         isNode = true
 
@@ -60,6 +59,7 @@ function NodeMixin<T extends Constructor>(Base: T) {
             super.updated(modifiedProps)
 
             if (modifiedProps.visible) {
+                this._forwardProp('visible', this.three)
                 console.log(
                     '                           visibility change',
                     this.constructor.name,

--- a/src/core/PointLight.ts
+++ b/src/core/PointLight.ts
@@ -7,32 +7,32 @@ import {prop} from '../html/WithUpdate'
 export default class PointLight extends LightBase {
     static defaultElementName = 'i-point-light'
 
-    @prop(mapPropTo({...props.number, default: 0}, (self: any) => self.three))
-    distance!: number
+    @prop(mapPropTo(props.number, (self: any) => self.three))
+    distance = 0
 
-    @prop(mapPropTo({...props.number, default: 1}, (self: any) => self.three))
-    decay!: number
+    @prop(mapPropTo(props.number, (self: any) => self.three))
+    decay = 1
 
-    @prop(mapPropTo({...props.boolean, default: true}, (self: any) => self.three))
-    castShadow!: boolean
+    @prop(mapPropTo(props.boolean, (self: any) => self.three))
+    castShadow = true
 
-    @prop({...props.number, default: 512})
-    shadowMapWidth!: number
+    @prop(Number)
+    shadowMapWidth = 512
 
-    @prop({...props.number, default: 512})
-    shadowMapHeight!: number
+    @prop(Number)
+    shadowMapHeight = 512
 
-    @prop({...props.number, default: 3})
-    shadowRadius!: number
+    @prop(Number)
+    shadowRadius = 3
 
-    @prop({...props.number, default: 0})
-    shadowBias!: number
+    @prop(Number)
+    shadowBias = 0
 
-    @prop({...props.number, default: 1})
-    shadowCameraNear!: number
+    @prop(Number)
+    shadowCameraNear = 1
 
-    @prop({...props.number, default: 2000})
-    shadowCameraFar!: number
+    @prop(Number)
+    shadowCameraFar = 2000
 
     three!: ThreePointLight
 

--- a/src/core/PointLight.ts
+++ b/src/core/PointLight.ts
@@ -1,38 +1,19 @@
 import {PointLight as ThreePointLight} from 'three'
 import LightBase from './LightBase'
-import {props} from './props'
-import {mapPropTo} from './props'
 import {prop} from '../html/WithUpdate'
 
 export default class PointLight extends LightBase {
     static defaultElementName = 'i-point-light'
 
-    @prop(mapPropTo(props.number, (self: any) => self.three))
-    distance = 0
-
-    @prop(mapPropTo(props.number, (self: any) => self.three))
-    decay = 1
-
-    @prop(mapPropTo(props.boolean, (self: any) => self.three))
-    castShadow = true
-
-    @prop(Number)
-    shadowMapWidth = 512
-
-    @prop(Number)
-    shadowMapHeight = 512
-
-    @prop(Number)
-    shadowRadius = 3
-
-    @prop(Number)
-    shadowBias = 0
-
-    @prop(Number)
-    shadowCameraNear = 1
-
-    @prop(Number)
-    shadowCameraFar = 2000
+    @prop(Number) distance = 0
+    @prop(Number) decay = 1
+    @prop(Boolean) castShadow = true
+    @prop(Number) shadowMapWidth = 512
+    @prop(Number) shadowMapHeight = 512
+    @prop(Number) shadowRadius = 3
+    @prop(Number) shadowBias = 0
+    @prop(Number) shadowCameraNear = 1
+    @prop(Number) shadowCameraFar = 2000
 
     three!: ThreePointLight
 
@@ -63,6 +44,10 @@ export default class PointLight extends LightBase {
         super.updated(modifiedProps)
 
         if (!this.isConnected) return
+
+        if (modifiedProps.distance) this._forwardProp('distance', this.three)
+        if (modifiedProps.decay) this._forwardProp('decay', this.three)
+        if (modifiedProps.castShadow) this._forwardProp('castShadow', this.three)
 
         const shadow = this.three.shadow
 

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -34,23 +34,12 @@ function SceneMixin<T extends Constructor>(Base: T) {
     class Scene extends Parent {
         static defaultElementName = 'i-scene'
 
-        @prop(props.THREE.Color)
-        backgroundColor!: Color | string | number
-
-        @prop(Number)
-        backgroundOpacity!: number
-
-        @prop(String)
-        shadowmapType!: ShadowMapTypeString
-
-        @prop(Boolean)
-        vr!: boolean
-
-        @prop(Boolean)
-        experimentalWebgl!: boolean
-
-        @prop(Boolean)
-        disableCss!: boolean
+        @prop(props.THREE.Color) backgroundColor!: Color | string | number
+        @prop(Number) backgroundOpacity!: number
+        @prop(String) shadowmapType!: ShadowMapTypeString
+        @prop(Boolean) vr!: boolean
+        @prop(Boolean) experimentalWebgl!: boolean
+        @prop(Boolean) disableCss!: boolean
 
         three!: ThreeScene
         threeCSS!: ThreeScene

--- a/src/core/Sizeable.ts
+++ b/src/core/Sizeable.ts
@@ -33,22 +33,16 @@ function SizeableMixin<T extends Constructor>(Base: T) {
     // calculating proportional sizes. Also Transformable knows about it's parent
     // in order to calculate it's world matrix based on it's parent's.
     class Sizeable extends Parent {
-        // TODO remove any
+        // TODO TS remove any
         // protected _properties: (typeof Parent)['_props']
-        protected _properties: any
+        protected _properties: any = this._props // alias to WithUpdate._props
 
         // TODO handle ctor arg types
         constructor(...args: any[]) {
             super(...args)
-            const options = args[0] || {}
 
             this.__calculatedSize = {x: 0, y: 0, z: 0}
-            this._properties = this._props // alias to WithUpdate._props
             this._setPropertyObservers()
-
-            // is there a better way, without having to expose public "properties" or "props" properties like we did before?
-            // this.properties = options
-            Object.assign(this, options)
         }
 
         // TODO types for props

--- a/src/core/props.ts
+++ b/src/core/props.ts
@@ -82,25 +82,25 @@ export const props = {
 
 // map a SkateJS prop value to another target specified by getTarget
 // NOTE `this` refers to the instance on which the prop exists
-export const mapPropTo = (prop: PropDefinitionObject, getTarget: (ctx: any) => object) => ({
-    ...prop,
-    coerce: prop.coerce
-        ? function coerce(this: any, val: any, key: string): any {
-              const target: any = getTarget.call(this, this)
-              const coerced = prop.coerce!.call(this, val, key)
-              if (target) target[key] = coerced
-              return coerced
-          }
-        : undefined,
-    deserialize: prop.deserialize
-        ? function deserialize(this: any, val: string, key: string): any {
-              const target: any = getTarget.call(this, this)
-              const deserialized = prop.deserialize!.call(this, val, key)
-              if (target) target[key] = deserialized
-              return deserialized
-          }
-        : undefined,
-})
+// export const mapPropTo = (prop: PropDefinitionObject, getTarget: (ctx: any) => object) => ({
+//     ...prop,
+//     coerce: prop.coerce
+//         ? function coerce(this: any, val: any, key: string): any {
+//               const target: any = getTarget.call(this, this)
+//               const coerced = prop.coerce!.call(this, val, key)
+//               if (target) target[key] = coerced
+//               return coerced
+//           }
+//         : undefined,
+//     deserialize: prop.deserialize
+//         ? function deserialize(this: any, val: string, key: string): any {
+//               const target: any = getTarget.call(this, this)
+//               const deserialized = prop.deserialize!.call(this, val, key)
+//               if (target) target[key] = deserialized
+//               return deserialized
+//           }
+//         : undefined,
+// })
 
 export const changePropContext = (prop: PropDefinitionObject, getContext: (ctx: any) => any) => ({
     ...prop,

--- a/src/html/behaviors/BaseGeometryBehavior.ts
+++ b/src/html/behaviors/BaseGeometryBehavior.ts
@@ -17,6 +17,9 @@ export default class BaseGeometryBehavior extends BaseMeshBehavior {
     updated(modifiedProps: any) {
         const {size, sizeMode} = modifiedProps
 
+        // if (size) this._forwardProp('size', this.element)
+        // if (sizeMode) this._forwardProp('sizeMode', this.element)
+
         if (size || sizeMode) {
             this.__updateGeometryOnSizeChange(this.size as XYZNonNegativeValues)
         }

--- a/src/html/behaviors/BaseMaterialBehavior.ts
+++ b/src/html/behaviors/BaseMaterialBehavior.ts
@@ -8,10 +8,10 @@ export default class BaseMaterialBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'material'
 
     @prop(props.THREE.Color)
-    color!: Color | string | number
+    color!: Color | string | number // no value specified, defaults to a random color
 
-    @prop({...props.number, default: 1})
-    opacity!: number
+    @prop(Number)
+    opacity = 1
 
     updated(modifiedProps: any) {
         const {color, opacity} = modifiedProps

--- a/src/html/behaviors/BaseMaterialBehavior.ts
+++ b/src/html/behaviors/BaseMaterialBehavior.ts
@@ -7,11 +7,8 @@ import {prop} from '../WithUpdate'
 export default class BaseMaterialBehavior extends BaseMeshBehavior {
     type: MeshComponentType = 'material'
 
-    @prop(props.THREE.Color)
-    color!: Color | string | number // no value specified, defaults to a random color
-
-    @prop(Number)
-    opacity = 1
+    @prop(props.THREE.Color) color!: Color | string | number // no value specified, defaults to a random color
+    @prop(Number) opacity = 1
 
     updated(modifiedProps: any) {
         const {color, opacity} = modifiedProps

--- a/src/html/behaviors/ForwardProps.ts
+++ b/src/html/behaviors/ForwardProps.ts
@@ -2,6 +2,11 @@ import {observe, unobserve} from 'james-bond'
 import {Mixin, MixinResult, Constructor} from 'lowclass'
 import {PossibleCustomElement} from '../WithUpdate'
 
+/**
+ * A mixin class that causes props from a specified objecet to be forwarded to this object.
+ * The consuming class (subclass) of this mixin class should define a protected
+ * _observedObject method which returns the object to be observed.
+ */
 function ForwardPropsMixin<T extends Constructor<HTMLElement>>(Base: T) {
     class ForwardProps extends Constructor<PossibleCustomElement>(Base) {
         constructor(...args: any[]) {

--- a/src/html/behaviors/MaterialTexture.ts
+++ b/src/html/behaviors/MaterialTexture.ts
@@ -10,8 +10,7 @@ import {Mesh} from '../../core'
 function MaterialTextureMixin<T extends Constructor<Behavior>>(Base: T) {
     // TODO, use a Pick<> of HTMLElement instead, pick just parts WithUpdate needs.
     class MaterialTexture extends WithUpdate.mixin(Constructor<Behavior>(Base)) {
-        @prop(String)
-        texture!: string
+        @prop(String) texture!: string
 
         element!: Mesh
 

--- a/src/html/behaviors/ObjModelBehavior.ts
+++ b/src/html/behaviors/ObjModelBehavior.ts
@@ -19,14 +19,12 @@ export default class ObjModelBehavior extends Behavior {
     /**
      * path to a `.obj` file
      */
-    @prop(String)
-    obj!: string
+    @prop(String) obj!: string
 
     /**
      * path to a `.mtl` file
      */
-    @prop(String)
-    mtl!: string
+    @prop(String) mtl!: string
 
     // TODO no any
     model: any

--- a/src/layout/AutoLayoutNode.ts
+++ b/src/layout/AutoLayoutNode.ts
@@ -49,8 +49,7 @@ export default class AutoLayoutNode extends Node {
         strict: false,
     }
 
-    @prop(String)
-    visualFormat!: string
+    @prop(String) visualFormat!: string
 
     /**
      * Constructor


### PR DESCRIPTION
This PR makes property definitions cleaner by removing the the `mapPropTo` helper and replacing it with the use of `_forwardProp` inside of `updated()` methods, puts prop definitions on one line if short enough, and continues work from https://github.com/infamous/infamous/pull/195 in assigning default values to properties using class fields.

The problem from https://github.com/infamous/infamous/pull/195#issuecomment-515801554 carries over to this PR as well currently.