### PR TITLE
delete unused import

### DIFF
--- a/src/core/Node.test.ts
+++ b/src/core/Node.test.ts
@@ -1,7 +1,6 @@
 import {Node} from './Node.js'
 import {Scene} from './Scene.js'
 import {defineElements} from '../index.js'
-import {Object3D} from 'three/src/core/Object3D.js'
 
 defineElements()
 


### PR DESCRIPTION
this PR solves reason of failing of CI.

> src/core/Node.test.ts:4:1 - error TS6133: 'Object3D' is declared but its value is never read.
4 import {Object3D} from 'three/src/core/Object3D.js'

https://github.com/lume/lume/runs/5300249809?check_suite_focus=true